### PR TITLE
Allows CSS output for fields, which settings are stored within arrays

### DIFF
--- a/src/postMessage.js
+++ b/src/postMessage.js
@@ -23,7 +23,7 @@ var kirkiPostMessage = {
 		 * @returns {void}
 		 */
 		add: function( id ) {
-			id = id.replace( '[', '-' ).replace( ']', '' );
+			id = id.replace(/[^\w\s]/gi, '-');
 			if ( null === document.getElementById( 'kirki-postmessage-' + id ) || 'undefined' === typeof document.getElementById( 'kirki-postmessage-' + id ) ) {
 				jQuery( 'head' ).append( '<style id="kirki-postmessage-' + id + '"></style>' );
 			}


### PR DESCRIPTION
This is related to: https://github.com/aristath/kirki/issues/2035#issuecomment-523599802
It simply replaces all special characters from a fields `settings` name instead of only the first `[` and `]`. This allows storing fields within nested arrays as theme-mod and also using this Postmessage module as expected.